### PR TITLE
feat: dynamic episode duration + AE-matched layout tuning + production CLI fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@ npx remotion render FullEpisode out/video.mp4 --props='{"audioSrc": "path/to/aud
 
 Automation CLI:
 ```bash
-npx ts-node src/automation/render-trigger.ts audio.mp3 --guest "Name" --ep 42 --title "Title"
-npx ts-node src/automation/render-trigger.ts clip.mp3 --clip --guest "Name" --hook "Hook text"
+npx tsx src/automation/render-trigger.ts audio.mp3 --guest "Name" --ep 42 --title "Title"
+npx tsx src/automation/render-trigger.ts clip.mp3 --clip --guest "Name" --hook "Hook text"
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ This opens a browser preview where you can see all compositions and adjust props
 
 ```bash
 # Full episode
-npx ts-node src/automation/render-trigger.ts audio.mp3 \
+npx tsx src/automation/render-trigger.ts audio.mp3 \
   --guest "Dr. Jane Doe" \
   --ep 42 \
   --title "Exploring the Unknown"
 
 # Social clip
-npx ts-node src/automation/render-trigger.ts clip.mp3 \
+npx tsx src/automation/render-trigger.ts clip.mp3 \
   --clip \
   --guest "Dr. Jane Doe" \
   --hook "This changed everything for me..."
@@ -140,17 +140,17 @@ For batch processing (recommended for hour-long episodes):
 
 ```bash
 # Add jobs to queue
-npx ts-node src/automation/render-trigger.ts audio1.mp3 --guest "Guest 1" --queue
-npx ts-node src/automation/render-trigger.ts audio2.mp3 --guest "Guest 2" --queue
+npx tsx src/automation/render-trigger.ts audio1.mp3 --guest "Guest 1" --queue
+npx tsx src/automation/render-trigger.ts audio2.mp3 --guest "Guest 2" --queue
 
 # Check queue status
-npx ts-node src/automation/render-queue.ts status
+npx tsx src/automation/render-queue.ts status
 
 # Process queue (run overnight)
 npm run render:all
 
 # Clear finished jobs
-npx ts-node src/automation/render-queue.ts clear
+npx tsx src/automation/render-queue.ts clear
 ```
 
 ### YouTube Upload
@@ -161,10 +161,10 @@ cp .env.example .env
 # Edit .env with your YouTube API credentials
 
 # Upload with queue
-npx ts-node src/automation/render-trigger.ts audio.mp3 --guest "Guest" --queue --upload
+npx tsx src/automation/render-trigger.ts audio.mp3 --guest "Guest" --queue --upload
 
 # Or upload directly
-npx ts-node src/automation/youtube-upload.ts output/video.mp4 "Video Title"
+npx tsx src/automation/youtube-upload.ts output/video.mp4 "Video Title"
 ```
 
 ---

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -71,6 +71,7 @@ const showTemplateSchema = z.object({
   templateConfig: OrientationSchema,
   audioSrc: z.string().optional(),
   episodeArtSrc: z.string().optional(),
+  durationInFrames: z.number().int().positive().optional(),
 });
 
 // WC horizontal template config (from shows/wonder-cabinet/video-template/template.json)
@@ -78,8 +79,8 @@ const wcHorizontalConfig = {
   width: 1920,
   height: 1080,
   layers: [
-    { type: "solid" as const, color: "#2d8c46", grain: true },
-    { type: "spiral" as const, asset: "bg-galaxy-spiral-1200w@2x.png", rotationSpeed: 0.5, opacity: 1.0 },
+    { type: "solid" as const, color: "#10a544", grain: true },
+    { type: "spiral" as const, asset: "bg-galaxy-spiral-1200w@2x.png", rotationSpeed: -0.5, opacity: 1.0 },
     { type: "cabinet-frame" as const, asset: "logo-primary-dark-bg-800w.png", artClip: true },
     { type: "title-image" as const, asset: "WonderCabinet-title.png", layout: "flanking" as const, leftAsset: "wonder.png", rightAsset: "cabinet.png" },
   ],
@@ -89,8 +90,8 @@ const wcVerticalConfig = {
   width: 1080,
   height: 1920,
   layers: [
-    { type: "solid" as const, color: "#2d8c46", grain: true },
-    { type: "spiral" as const, asset: "bg-galaxy-spiral-1200w@2x.png", rotationSpeed: 0.5, opacity: 1.0 },
+    { type: "solid" as const, color: "#10a544", grain: true },
+    { type: "spiral" as const, asset: "bg-galaxy-spiral-1200w@2x.png", rotationSpeed: -0.5, opacity: 1.0 },
     { type: "cabinet-frame" as const, asset: "logo-primary-dark-bg-800w.png", artClip: true },
     { type: "title-image" as const, asset: "WonderCabinet-title.png", layout: "stacked" as const },
   ],
@@ -299,6 +300,9 @@ export const RemotionRoot: React.FC = () => {
           audioSrc: staticFile("WC_S01_trailer.mp3"),
           episodeArtSrc: "",
         }}
+        calculateMetadata={({ props }) => ({
+          durationInFrames: props.durationInFrames ?? 30 * 60,
+        })}
       />
 
       <Composition
@@ -314,6 +318,9 @@ export const RemotionRoot: React.FC = () => {
           audioSrc: staticFile("WC_S01_trailer.mp3"),
           episodeArtSrc: "",
         }}
+        calculateMetadata={({ props }) => ({
+          durationInFrames: props.durationInFrames ?? 30 * 60,
+        })}
       />
     </>
   );

--- a/src/automation/render-trigger.ts
+++ b/src/automation/render-trigger.ts
@@ -19,6 +19,7 @@
  */
 
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { spawn } from "child_process";
 import { addJob, processQueue } from "./render-queue";
@@ -131,10 +132,28 @@ async function renderDirect(
     fs.mkdirSync(OUTPUT_DIR, { recursive: true });
   }
 
-  // Build props
+  const publicDir = path.join(__dirname, "../../public");
+  if (!fs.existsSync(publicDir)) {
+    fs.mkdirSync(publicDir, { recursive: true });
+  }
+
+  // Track files copied into public/ so we can clean them up after render.
+  const publicCopies: string[] = [];
+
+  // Audio: Remotion <Audio src={...}> needs a staticFile()-resolvable filename.
+  // Copy (or hardlink-fallback to copy) the source audio into public/.
+  const resolvedAudio = path.resolve(options.audioPath);
+  const audioFilename = `episode-audio-${Date.now()}${path.extname(options.audioPath)}`;
+  const audioInPublic = path.join(publicDir, audioFilename);
+  fs.copyFileSync(resolvedAudio, audioInPublic);
+  publicCopies.push(audioInPublic);
+
+  // Build props. durationInFrames is passed so the WC-Horizontal/Vertical
+  // compositions can override their default 60s duration via calculateMetadata.
   const props: Record<string, unknown> = {
-    audioSrc: path.resolve(options.audioPath),
+    audioSrc: audioFilename,
     guestName: options.guestName,
+    durationInFrames,
   };
 
   if (options.episodeNumber) props.episodeNumber = options.episodeNumber;
@@ -150,11 +169,9 @@ async function renderDirect(
     }
     // Copy to public/ so Remotion can serve it via staticFile()
     const artFilename = `episode-art-${Date.now()}${path.extname(options.episodeArtPath)}`;
-    const publicDir = path.join(__dirname, "../../public");
-    if (!fs.existsSync(publicDir)) {
-      fs.mkdirSync(publicDir, { recursive: true });
-    }
-    fs.copyFileSync(resolvedArt, path.join(publicDir, artFilename));
+    const artInPublic = path.join(publicDir, artFilename);
+    fs.copyFileSync(resolvedArt, artInPublic);
+    publicCopies.push(artInPublic);
     props.episodeArtSrc = artFilename;
   }
 
@@ -167,22 +184,33 @@ async function renderDirect(
   console.log(`Output: ${outputPath}`);
   console.log("═".repeat(60));
 
+  // Write props to a temp JSON file rather than passing as a CLI string.
+  // shell-tokenization mangles JSON quotes/braces; --props=<file> avoids it.
+  const propsFile = path.join(os.tmpdir(), `remotion-props-${Date.now()}.json`);
+  fs.writeFileSync(propsFile, JSON.stringify(props));
+
   return new Promise((resolve, reject) => {
     const args = [
       "remotion",
       "render",
       composition,
       outputPath,
-      `--props=${JSON.stringify(props)}`,
-      `--frames=0-${durationInFrames - 1}`,
+      `--props=${propsFile}`,
     ];
 
     const render = spawn("npx", args, {
       stdio: "inherit",
-      shell: true,
     });
 
+    const cleanup = () => {
+      try { fs.unlinkSync(propsFile); } catch {}
+      for (const f of publicCopies) {
+        try { fs.unlinkSync(f); } catch {}
+      }
+    };
+
     render.on("close", (code) => {
+      cleanup();
       if (code === 0) {
         resolve(outputPath);
       } else {
@@ -190,7 +218,10 @@ async function renderDirect(
       }
     });
 
-    render.on("error", reject);
+    render.on("error", (err) => {
+      cleanup();
+      reject(err);
+    });
   });
 }
 

--- a/src/template/ShowTemplate.tsx
+++ b/src/template/ShowTemplate.tsx
@@ -1,10 +1,15 @@
 import React from "react";
-import { AbsoluteFill, Audio } from "remotion";
+import { AbsoluteFill, Audio, staticFile } from "remotion";
 import { OrientationConfig, LayerDef } from "./types";
 import { SolidBackground } from "./layers/SolidBackground";
 import { GalaxySpiral } from "./layers/GalaxySpiral";
 import { CabinetFrame } from "./layers/CabinetFrame";
 import { TitleImage } from "./layers/TitleImage";
+
+// Resolve an asset src that might be a bare filename (needs staticFile)
+// or already a fully-formed URL (from defaultProps where staticFile was applied).
+const resolveAssetSrc = (src: string): string =>
+  /^(https?:|\/|file:)/.test(src) ? src : staticFile(src);
 
 export interface ShowTemplateProps {
   /** Template layer configuration (from template.json) */
@@ -38,7 +43,7 @@ export const ShowTemplate: React.FC<ShowTemplateProps> = ({
           episodeArtSrc={episodeArtSrc}
         />
       ))}
-      {hasAudio && <Audio src={audioSrc!} />}
+      {hasAudio && <Audio src={resolveAssetSrc(audioSrc!)} />}
     </AbsoluteFill>
   );
 };

--- a/src/template/layers/TitleImage.tsx
+++ b/src/template/layers/TitleImage.tsx
@@ -28,14 +28,16 @@ export const TitleImage: React.FC<TitleImageProps> = ({
   const { width, height } = useVideoConfig();
 
   if (layout === "flanking" && leftAsset && rightAsset) {
-    // AE ref: title text is ~5.6% of frame height, centered at ~41.5% height
-    const wordHeight = height * 0.056;
+    // AE ref: measured WONDER wordmark width = 535px on 1920 frame.
+    // wonder.png aspect after trim = 2314/261 = 8.866. Target render
+    // height = 535 / 8.866 = 60.3px = 5.58% of 1080. Use 0.057 to match.
+    const wordHeight = height * 0.057;
     return (
       <AbsoluteFill>
         <div
           style={{
             position: "absolute",
-            left: width * 0.05,
+            left: width * 0.025,
             top: "41.5%",
             transform: "translateY(-50%)",
             height: wordHeight,
@@ -49,7 +51,7 @@ export const TitleImage: React.FC<TitleImageProps> = ({
         <div
           style={{
             position: "absolute",
-            right: width * 0.05,
+            right: width * 0.025,
             top: "41.5%",
             transform: "translateY(-50%)",
             height: wordHeight,

--- a/src/template/types.ts
+++ b/src/template/types.ts
@@ -13,7 +13,7 @@ export const LayerDefSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("spiral"),
     asset: z.string(),
-    rotationSpeed: z.number().positive().optional(),
+    rotationSpeed: z.number().optional(),
     opacity: z.number().min(0).max(1).optional(),
   }),
   z.object({


### PR DESCRIPTION
## Summary

- WC-Horizontal/Vertical compositions now compute `durationInFrames` at render time via `calculateMetadata`, so the production CLI (`render-trigger.ts`) can render full-length episodes instead of being capped at the 60s default. Removes the need for per-episode one-off `<Composition>` entries in Root.tsx.
- Layout tuning to match the AE reference template: `wordHeight 0.056 → 0.057` for cap-height match, edge inset `0.05 → 0.025` for proper cabinet flanking, brand-spec green (`#10a544`), counter-clockwise spiral rotation.
- Production CLI fixes: temp JSON file for `--props` (avoids shell-tokenization mangling), audio copied to `public/` for `staticFile()` resolution, `durationInFrames` passed in props, `tsx` instead of broken-on-ESM `ts-node` in docs.

## Validated end-to-end

- 60-sec smoke render via `render-trigger.ts` produces correct output with audio + art clipped into cabinet.
- Full E12 Henderson render (89,716 frames / 49m 50s) completed in 1h 22m wall-clock (1.66× realtime), 5.3GB MP4, audio sync within single-frame tolerance.

## Test plan
- [ ] `npm run typecheck` passes locally (verified during dev)
- [ ] `npx remotion still WC-Horizontal /tmp/test.png --props='{"episodeArtSrc":"some-art.jpg"}'` renders successfully
- [ ] `npx tsx src/automation/render-trigger.ts <audio> --episode --show wonder-cabinet --art <jpg> --guest <name>` produces a video in `OUTPUT_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)